### PR TITLE
Add Social Path

### DIFF
--- a/pacifica/auth/application.py
+++ b/pacifica/auth/application.py
@@ -62,7 +62,8 @@ def social_settings(configparser: ConfigParser, user_class, user_import_path):
         'SOCIAL_AUTH_LOGIN_REDIRECT_URL': '/',
         'SOCIAL_AUTH_TRAILING_SLASH': True,
         'SOCIAL_AUTH_AUTHENTICATION_BACKENDS': (
-            'social_core.backends.{}.{}'.format(
+            '{}.{}.{}'.format(
+                configparser.get('cherrypy', 'social_path'),
                 configparser.get('cherrypy', 'social_module'),
                 configparser.get('cherrypy', 'social_class')
             ),

--- a/pacifica/auth/config.py
+++ b/pacifica/auth/config.py
@@ -26,6 +26,8 @@ def common_config(configparser: ConfigParser):
         'CHERRYPY_SOCIAL_MODULE', 'github'))
     configparser.set('cherrypy', 'social_class', getenv(
         'CHERRYPY_SOCIAL_CLASS', 'GithubOAuth2'))
+    configparser.set('cherrypy', 'social_path', getenv(
+        'CHERRYPY_SOCIAL_PATH', 'social_core.backends'))
     configparser.add_section('social_settings')
     configparser.add_section('database')
     configparser.set('database', 'db_url', getenv(


### PR DESCRIPTION
### Description

This adds a config option to specify the path to the social
module. This allows for custom auth backends for social auth.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
